### PR TITLE
Fix on python install package, change the hostname on the vagrant mac…

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -76,7 +76,7 @@ Vagrant.configure("2") do |config|
 	end
 
 	config.vm.define 'redis', primary: true do |m|
-		m.vm.host_name = "postgres"
+		m.vm.host_name = "redis"
 		m.vm.network "forwarded_port", guest: 6379, host: 6379
 		m.vm.provider "virtualbox" do |vb|
 			vb.name = "redis"

--- a/provision/install_python.sh
+++ b/provision/install_python.sh
@@ -12,7 +12,8 @@ then
 	yum group install development -y
 	yum install zlib-devel -y
 	yum install -y install https://centos7.iuscommunity.org/ius-release.rpm
-	yum -y install python36u python36u-pip python36u-devel git
+	#yum -y install python36u python36u-pip python36u-devel git
+	yum -y install python3 python3-libs python3-pip python3-setuptools python3-devel python3-wheel git
 
 	ln -s /usr/bin/python3.6 /usr/bin/python3
 

--- a/provision/update_vbox_guest.py
+++ b/provision/update_vbox_guest.py
@@ -4,5 +4,5 @@ from chibi.command.echo import cowsay
 
 
 cowsay( "starting update vbox guest" )
-command( '/opt/VBoxGuestAdditions-5.*/init/vboxadd', 'setup' )
+command( '/opt/VBoxGuestAdditions-*/init/vboxadd', 'setup' )
 cowsay( "ending update vbox guest" )


### PR DESCRIPTION
Several Fixes on the Vagrant Virtual Machines Deployment.

- Fix on python install package
- Change the hostname on the vagrant machine for redis
- Change on vbox ghest update for appoint to the right VBoxGuestAdditions